### PR TITLE
Fix: Resolve document is not defined Error for Mapbox Searchbox in Next.js

### DIFF
--- a/web_app/hazard-reporting-map/pages/volunteers/index.tsx
+++ b/web_app/hazard-reporting-map/pages/volunteers/index.tsx
@@ -1,3 +1,4 @@
+import dynamic from 'next/dynamic';
 import DataTable, { TDataTableColumn } from '@/components/DataTable';
 import Container from '@/components/layouts/Container';
 import { Badge } from '@/components/ui/badge';
@@ -29,7 +30,13 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import ReactPaginate from 'react-paginate';
-import AddVolunteer from '@/components/modals/volunteers/AddVolunteer';
+
+const AddVolunteer = dynamic(
+  () => import('@/components/modals/volunteers/AddVolunteer'),
+  {
+    ssr: false,
+  }
+);
 
 export default function Dashboard() {
   const [searchInput, setSearchInput] = useState('');


### PR DESCRIPTION
This pull request addresses an issue where the Mapbox Searchbox component was causing a document is not defined error due to server-side rendering. By default, Next.js performs server-side rendering, and the Mapbox's Searchbox relies on browser-specific objects like document, which are not available on the server.

- Updated the implementation to ensure that the Mapbox Searchbox component only renders on the client side.
- Used dynamic imports with ssr: false to prevent server-side rendering of the component.